### PR TITLE
libzmq3, libzmq3-dev travis dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,8 @@ addons:
     - gfortran-4.8
     - git
     - cmake
+    - libzmq3
+    - libzmq3-dev
 # blocked by https://github.com/travis-ci/apt-source-whitelist/issues/149
 #            https://github.com/travis-ci/apt-source-whitelist/pull/150
 #    - libzmq3-dev=4.0.5-1chl1~precise1


### PR DESCRIPTION
Haven't fixed the build completely.  Only have fixed broken dependency of `zeromq4-haskell` on libzmq:
https://travis-ci.org/ghorn/dynobud/builds/220325850#L2140-L2142

New errors exposed:
https://travis-ci.org/peterbecich/dynobud/builds/228136051#L550-L718